### PR TITLE
Fixed GCC flags being applied to MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project (node-raylib)
 
 if ( CMAKE_COMPILER_IS_GNUCC )
     set(CMAKE_C_FLAGS "-fPIC ${CMAKE_C_FLAGS} -Wno-unused-result")
+    set(CMAKE_CXX_FLAGS "-Wall -Wextra")
 endif()
 if ( MSVC )
     set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} /w")
@@ -12,7 +13,6 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-set(CMAKE_CXX_FLAGS "-Wall -Wextra")
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 


### PR DESCRIPTION
The -Wall and -Wextra flags were causing a compilation error on windows with the visual studio/MSVC compiler making the module not install.
`cl : command line error D8021: invalid numeric argument '/Wextra' [node_modules\raylib\build\
node-raylib.vcxproj]`