### PR TITLE
Add checking arm for Raspberry Pi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,11 @@ endif()
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
+# raylib
+if(${NODE_ARCH} STREQUAL "arm" OR ${NODE_ARCH} STREQUAL "arm64")
+  set(PLATFORM "Raspberry Pi")
+endif()
+
 # TODO: Move this to cmake/FindRaylib.cmake?
 find_package(raylib 3.0.0)
 if (NOT raylib_FOUND)


### PR DESCRIPTION
Check the architecture in CMake to pass off `Raspberry Pi` to `PLATFORM`.

@daniel-thd-labs @armageddon421 Maybe something like this works? Mind checking out the branch and doing a `npm it` to see if it works? Thanks!

https://github.com/RobLoach/node-raylib/issues/61