### PR TITLE
Add argument orchestrator for 'unsigned char *'

### DIFF
--- a/examples/textures/textures_from_memory.js
+++ b/examples/textures/textures_from_memory.js
@@ -1,0 +1,69 @@
+/*******************************************************************************************
+*
+*   raylib [textures] example - Image loading and texture creation from memory
+*
+*   NOTE: Images are loaded in CPU memory (RAM); textures are loaded in GPU memory (VRAM)
+*
+*   This example has been created using raylib 3.5 (www.raylib.com)
+*   raylib is licensed under an unmodified zlib/libpng license (View raylib.h for details)
+*
+********************************************************************************************/
+
+const r = require('raylib')
+const { resolve } = require('path')
+const { readFileSync } = require('fs')
+
+// Initialization
+//--------------------------------------------------------------------------------------
+const screenWidth = 800;
+const screenHeight = 450;
+
+// Load the image using fs module into a `Buffer` instance.
+// NOTE: this `Buffer` could come from *anywhere* (statically encoded in your source code, as a
+// partial read from a custom resource packer file, etc.)
+const raw = readFileSync(resolve(__dirname, 'resources', 'wabbit_alpha.png'));
+
+r.InitWindow(screenWidth, screenHeight, "raylib [textures] example - image loading from memory");
+
+// NOTE: Textures MUST be loaded after Window initialization (OpenGL context is required)
+const image = r.LoadImageFromMemory('png', raw, raw.length);     // Loaded in CPU memory (RAM)
+if (! image.data) {
+	console.error('image failed to load!');
+	process.exit(1);
+}
+
+// TODO: Fix thrown exception
+// INFO: [/home/rob/Documents/node-raylib/examples/textures/resources/raylib_logo.png] Image loaded successfully (256x256)
+// terminate called after throwing an instance of 'char const*'
+// [1]    26364 abort (core dumped)  bin/node-raylib examples/textures/textures_image_loading.js
+
+const texture = r.LoadTextureFromImage(image);          // Image converted to texture, GPU memory (VRAM)
+
+r.UnloadImage(image);   // Once image has been converted to texture and uploaded to VRAM, it can be unloaded from RAM
+//---------------------------------------------------------------------------------------
+
+// Main game loop
+while (!r.WindowShouldClose())    // Detect window close button or ESC key
+{
+    // Update
+	
+    // Draw
+    //----------------------------------------------------------------------------------
+    r.BeginDrawing();
+
+        r.ClearBackground(r.RAYWHITE);
+
+        r.DrawTexture(texture, screenWidth/2 - texture.width/2, screenHeight/2 - texture.height/2, r.WHITE);
+
+        r.DrawText("this IS a texture loaded from memory!", 300, 370, 10, r.GRAY);
+
+    r.EndDrawing();
+    //----------------------------------------------------------------------------------
+}
+
+// De-Initialization
+//--------------------------------------------------------------------------------------
+r.UnloadTexture(texture);       // Texture unloading
+
+r.CloseWindow();                // Close window and OpenGL context
+//--------------------------------------------------------------------------------------

--- a/src/lib/GetArgFromParam.h
+++ b/src/lib/GetArgFromParam.h
@@ -37,6 +37,14 @@ const char* GetArgFromParam<const char*>(Napi::Env& env, const Napi::CallbackInf
 }
 
 template <>
+const unsigned char* GetArgFromParam<const unsigned char*>(Napi::Env& env, const Napi::CallbackInfo& info, int paramNum) {
+  (void)env;
+  Napi::Buffer<unsigned char> buf = info[paramNum].As<Napi::Buffer<unsigned char>>();
+  return (const unsigned char*) buf.Data();
+}
+
+
+template <>
 int GetArgFromParam<int>(Napi::Env& env, const Napi::CallbackInfo& info, int paramNum) {
   (void)env;
   return info[paramNum].As<Napi::Number>().Int32Value();

--- a/src/lib/GetArgFromParam.h
+++ b/src/lib/GetArgFromParam.h
@@ -43,7 +43,6 @@ const unsigned char* GetArgFromParam<const unsigned char*>(Napi::Env& env, const
   return (const unsigned char*) buf.Data();
 }
 
-
 template <>
 int GetArgFromParam<int>(Napi::Env& env, const Napi::CallbackInfo& info, int paramNum) {
   (void)env;


### PR DESCRIPTION
* Necessary to support the LoadXXXXFromMemory() methods, ex:
```js
const raw = fs.readFileSync('wabbits_alpha.png');
const imgBunny = r.LoadImageFromMemory('png', raw, raw.length);
if (! imgBunny.data) {
  console.error('failed to load image!');
  process.exit(1);
}

const texBunny = r.LoadTextureFromImage(imgBunny);
if (! texBunny.id) {
  console.error('failed to load texture!');
  process.exit(1);
}

/* ... */

r.UnloadTexture(texBunny);
r.UnloadImage(imgBunny);
```
* Considered a wrap to get rid of the somewhat superfluous length parameter but this was quicker -- one can always wrap it on the Node.js side if its bothersome :)