### PR TITLE
Fix missing TypeScript bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "vendor/*",
     "CMakeLists.txt",
     "index.js",
-    "index.d.js",
+    "index.d.ts",
     "package.json",
     "README.md",
     "LICENSE.md",


### PR DESCRIPTION
Just noticed they weren't being included in the package and this should fix it.