### PR TITLE
use cmake instead of submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/raylib"]
-	path = vendor/raylib
-	url = https://github.com/raysan5/raylib.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,12 +20,22 @@ endif()
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
-# TODO: Move this to cmake/FindRaylib.cmake?
-find_package(raylib 3.5.0)
+# version doesn't seem to pick correct version
+#find_package(raylib 3.5 QUIET EXACT)
 if (NOT raylib_FOUND)
-  set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE) # don't build the supplied examples
-  set(BUILD_GAMES    OFF CACHE BOOL "" FORCE) # or games
-  add_subdirectory(vendor/raylib)
+  include(FetchContent)
+  FetchContent_Declare(
+    raylib
+    GIT_REPOSITORY https://github.com/raysan5/raylib.git
+    GIT_TAG 3.5.0
+  )
+  FetchContent_GetProperties(raylib)
+  if (NOT raylib_POPULATED)
+    set(FETCHCONTENT_QUIET NO)
+    FetchContent_Populate(raylib)
+    set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    add_subdirectory(${raylib_SOURCE_DIR} ${raylib_BINARY_DIR})
+  endif()
 endif()
 
 # Add all the include directories.

--- a/README.md
+++ b/README.md
@@ -84,8 +84,7 @@ The following are a few notes and resources when developing `node-raylib`...
 ```
 git clone https://github.com/RobLoach/node-raylib.git
 cd node-raylib
-git submodule update --init
-npm it
+npm i
 ```
 
 ### TypeScript Definitions


### PR DESCRIPTION
This addresses build issues like #97 and #98 on windows, mac, and linux. Basically it uses a git-clone that cmake manages to build, instead of relying on system-wide libraries or a submodule.  This means lighter npm, it's easier to deal with in instructions (no `submodule stuff or `--recursive` clone) and it drops the check for the system-wide raylib (which seems broken, at least on mac/linux.)