### PR TITLE
no CLI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ The project comes with a [`node-raylib`](https://github.com/RobLoach/node-raylib
 
 ``` bash
 # Unix
-./node-raylib core_basic_window.js
+./bin/node-raylib core_basic_window.js
 
 # Windows
-node-raylib.exe core_basic_window.js
+node bin/node-raylib core_basic_window.js
 ```
 
-The CLI can be installed with the [packaged releases](https://github.com/RobLoach/node-raylib/releases), or globally through `npm` or `npx` for no-install:
+The CLI can be installed globally through `npm` or `npx` for no-install:
 
 ``` bash
 npm install raylib --global


### PR DESCRIPTION
The CLI is no longer being built in CI, so the README has invalid instructions. This just removes that (leaving npx/npm instructions.) Alternately, we could build the CLI for x86_64 targets in CI, but I think we need to do some research around building a standalone exe (pkg, for example, doesn't inline the native lib.)