### PR TITLE
Avoid packaging the docs folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   ],
   "license": "Zlib",
   "files": [
-    "docs/*",
     "bin/*",
     "man/node-raylib.1",
     "src/*",


### PR DESCRIPTION
We probably don't need to distribute the docs folder with the npm package.