### PR TITLE
Crossbuild

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,66 @@ jobs:
           body: This is an automated release for ${{ github.ref }}. It will be used to speed up `npm install`.
         env:
           GITHUB_TOKEN: ${{ github.token }}
+  linux-arm:
+    runs-on: ubuntu-latest
+    needs: create_release
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Cache Node Dependencies
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: ./node_modules
+          key: modules-${{ hashFiles('package-lock.json') }}
+      - name: Install Node Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci --ignore-scripts
+      - name: Build for arm
+        run: docker run --platform linux/arm -it --rm -v "${PWD}:/work" -w /work node ./tools/crossbuild.sh
+      - name: upload linux artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: ./build/Release/node-raylib.node
+          asset_name: node-raylib-4.0-linux-arm.node
+          asset_content_type: application/octet-stream
+  linux-arm64:
+    runs-on: ubuntu-latest
+    needs: create_release
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Cache Node Dependencies
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: ./node_modules
+          key: modules-${{ hashFiles('package-lock.json') }}
+      - name: Install Node Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci --ignore-scripts
+      - name: Build for arm
+        run: docker run --platform linux/arm64 -it --rm -v "${PWD}:/work" -w /work node ./tools/crossbuild.sh
+      - name: upload linux artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: ./build/Release/node-raylib.node
+          asset_name: node-raylib-4.0-linux-arm64.node
+          asset_content_type: application/octet-stream
   linux:
     runs-on: ubuntu-latest
     needs: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,6 @@ jobs:
         with:
           path: ./node_modules
           key: modules-${{ hashFiles('package-lock.json') }}
-      - name: Install Node Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci --ignore-scripts
       - name: Build for arm
         run: docker run --platform linux/arm -it --rm -v "${PWD}:/work" -w /work node ./tools/crossbuild.sh
       - name: upload linux artifact
@@ -67,9 +64,6 @@ jobs:
         with:
           path: ./node_modules
           key: modules-${{ hashFiles('package-lock.json') }}
-      - name: Install Node Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci --ignore-scripts
       - name: Build for arm
         run: docker run --platform linux/arm64 -it --rm -v "${PWD}:/work" -w /work node ./tools/crossbuild.sh
       - name: upload linux artifact

--- a/tools/crossbuild.sh
+++ b/tools/crossbuild.sh
@@ -3,7 +3,7 @@
 # this is used inside a docker (running with qemu binfmt) to easily crossbuild project
 # run with docker run --platform linux/arm64 -it --rm -v "${PWD}:/work" -w /work node ./tools/crossbuild.sh
 
-apt update
-apt install -y xorg-dev libglu1-mesa-dev
-npm i
+apt-get update
+apt-get install -y xorg-dev libglu1-mesa-dev cmake
+npm ci
 npm run compile

--- a/tools/crossbuild.sh
+++ b/tools/crossbuild.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# this is used inside a docker (running with qemu binfmt) to easily crossbuild project
+# run with docker run --platform linux/arm64 -it --rm -v "${PWD}:/work" -w /work node ./tools/crossbuild.sh
+
+apt update
+apt install -y xorg-dev libglu1-mesa-dev
+npm i
+npm run compile


### PR DESCRIPTION
This is untested, in the context of the github action. but the script can be used to cross-build for linux arm & arm64:

```
docker run --platform linux/arm -it --rm -v "${PWD}:/work" -w /work node ./tools/crossbuild.sh
docker run --platform linux/arm64 -it --rm -v "${PWD}:/work" -w /work node ./tools/crossbuild.sh
```

You need qemu & binfmt setup (so you can cross-run docker) which as I understand it `docker/setup-qemu-action` action does, so I added that to the workflows.

Even if the action doesn't work, the script makes it easier for me to build for linux arm & arm64 on my Mac M1.
