### PR TITLE
use single build for mac

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,5 +213,5 @@ jobs:
         with:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
           asset_path: ./build/Release/node-raylib.node
-          asset_name: node-raylib-darwin-x64.node
+          asset_name: node-raylib-darwin.node
           asset_content_type: application/octet-stream

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ endif()
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
+# single build for both Mac arches
+set(CMAKE_OSX_ARCHITECTURES arm64 x86_64)
+
 # version doesn't seem to pick correct version
 #find_package(raylib 4.5 QUIET EXACT)
 if (NOT raylib_FOUND)

--- a/tools/postinstall.js
+++ b/tools/postinstall.js
@@ -33,6 +33,11 @@ async function main () {
 
   let url = `https://github.com/RobLoach/node-raylib/releases/download/v${process.env.npm_package_version}/node-raylib-${process.platform}-${process.arch}.node`
 
+  // we use a single build for both platforms on Mac
+  if (process.platform === 'darwin') {
+    url = `https://github.com/RobLoach/node-raylib/releases/download/v${process.env.npm_package_version}/node-raylib-darwin.node`
+  }
+
   console.log(`Checking for ${url}`)
 
   try {


### PR DESCRIPTION
This changes mac to always use a single "fat" library that supports ARM (M1/M4) and Intel both.

It will build both in cmake, CI will build a single file, and the postinstall script will download the single file, instead of CPU-specific.