### PR TITLE
prevent postinstall from running if compiled binary already exists

### DIFF
--- a/tools/postinstall.js
+++ b/tools/postinstall.js
@@ -1,7 +1,7 @@
 // this is run after npm install
 // download pre-made module, if possible & exit 1, or exit 0 to tell system if it needs to build
 
-const { fs } = require("node:fs/promises");
+const fs = require("node:fs/promises");
 const path = require("node:path");
 const fetch = require("cross-fetch");
 


### PR DESCRIPTION
The `postinstall` script is incorrectly importing the `fs` module causing it to be undefined, which causes this script to resort to compiling the `.node` binary on every install.