### PR TITLE
Adding CMAKE_JS_SRC allows bundled .exe names to change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ add_library(${PROJECT_NAME} SHARED
   # src/node-rlgl.h
   # src/lib/WrappedFunctions.h
   src/generated/node-raylib.cc
+  ${CMAKE_JS_SRC}
 )
 
 ## Suffix the node module with .node.


### PR DESCRIPTION
This change makes it so the node-raylib module can be included in bundled SEA applications with the .exe name changed to anything else

The change to the CMakeLists.txt includes code from cmake-js to change the dll loading pattern to a delay load hook. The DLL entry point will no longer look for the process by .exe name to identify where to load (I'm not sure the exact details here on how it works fully) so it's more flexible.

Help from these two issues helped identify the solution:
https://github.com/RobLoach/node-raylib/issues/74
https://github.com/nodejs/node/issues/59574



