### PR TITLE
Add support for more Buffer types

### DIFF
--- a/src/generated/node-raylib-drm.js
+++ b/src/generated/node-raylib-drm.js
@@ -1490,7 +1490,7 @@ raylib.MemFree = MemFree
  * @param {string} fileName
  * @param {number} dataSize
  *
- * @return {Buffer} The resulting unsigned char *.
+ * @return {Buffer|ArrayBuffer|ArrayBufferView} The resulting unsigned char *.
  */
 function LoadFileData(fileName, dataSize) {
   return r.BindLoadFileData(
@@ -1503,7 +1503,7 @@ raylib.LoadFileData = LoadFileData
 /**
  * Unload file data allocated by LoadFileData()
  *
- * @param {Buffer} data
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} data
  *
  * @return {undefined}
  */
@@ -1535,7 +1535,7 @@ raylib.SaveFileData = SaveFileData
 /**
  * Export data to code (.h), returns true on success
  *
- * @param {Buffer} data
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} data
  * @param {number} dataSize
  * @param {string} fileName
  *
@@ -1899,11 +1899,11 @@ raylib.GetFileModTime = GetFileModTime
 /**
  * Compress data (DEFLATE algorithm), memory must be MemFree()
  *
- * @param {Buffer} data
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} data
  * @param {number} dataSize
  * @param {number} compDataSize
  *
- * @return {Buffer} The resulting unsigned char *.
+ * @return {Buffer|ArrayBuffer|ArrayBufferView} The resulting unsigned char *.
  */
 function CompressData(data, dataSize, compDataSize) {
   return r.BindCompressData(
@@ -1917,11 +1917,11 @@ raylib.CompressData = CompressData
 /**
  * Decompress data (DEFLATE algorithm), memory must be MemFree()
  *
- * @param {Buffer} compData
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} compData
  * @param {number} compDataSize
  * @param {number} dataSize
  *
- * @return {Buffer} The resulting unsigned char *.
+ * @return {Buffer|ArrayBuffer|ArrayBufferView} The resulting unsigned char *.
  */
 function DecompressData(compData, compDataSize, dataSize) {
   return r.BindDecompressData(
@@ -1935,7 +1935,7 @@ raylib.DecompressData = DecompressData
 /**
  * Encode data to Base64 string, memory must be MemFree()
  *
- * @param {Buffer} data
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} data
  * @param {number} dataSize
  * @param {number} outputSize
  *
@@ -1953,10 +1953,10 @@ raylib.EncodeDataBase64 = EncodeDataBase64
 /**
  * Decode Base64 string data, memory must be MemFree()
  *
- * @param {Buffer} data
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} data
  * @param {number} outputSize
  *
- * @return {Buffer} The resulting unsigned char *.
+ * @return {Buffer|ArrayBuffer|ArrayBufferView} The resulting unsigned char *.
  */
 function DecodeDataBase64(data, outputSize) {
   return r.BindDecodeDataBase64(
@@ -1969,7 +1969,7 @@ raylib.DecodeDataBase64 = DecodeDataBase64
 /**
  * Compute CRC32 hash code
  *
- * @param {Buffer} data
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} data
  * @param {number} dataSize
  *
  * @return {number} The resulting unsigned int.
@@ -1985,7 +1985,7 @@ raylib.ComputeCRC32 = ComputeCRC32
 /**
  * Compute MD5 hash code, returns static int[4] (16 bytes)
  *
- * @param {Buffer} data
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} data
  * @param {number} dataSize
  *
  * @return {number} The resulting unsigned int *.
@@ -2001,7 +2001,7 @@ raylib.ComputeMD5 = ComputeMD5
 /**
  * Compute SHA1 hash code, returns static int[5] (20 bytes)
  *
- * @param {Buffer} data
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} data
  * @param {number} dataSize
  *
  * @return {number} The resulting unsigned int *.
@@ -4393,7 +4393,7 @@ raylib.LoadImageAnim = LoadImageAnim
  * Load image sequence from memory buffer
  *
  * @param {string} fileType
- * @param {Buffer} fileData
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} fileData
  * @param {number} dataSize
  * @param {number} frames
  *
@@ -4413,7 +4413,7 @@ raylib.LoadImageAnimFromMemory = LoadImageAnimFromMemory
  * Load image from memory buffer, fileType refers to extension: i.e. '.png'
  *
  * @param {string} fileType
- * @param {Buffer} fileData
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} fileData
  * @param {number} dataSize
  *
  * @return {Image} The resulting Image.
@@ -4518,7 +4518,7 @@ raylib.ExportImage = ExportImage
  * @param {string} fileType
  * @param {number} fileSize
  *
- * @return {Buffer} The resulting unsigned char *.
+ * @return {Buffer|ArrayBuffer|ArrayBufferView} The resulting unsigned char *.
  */
 function ExportImageToMemory(image, fileType, fileSize) {
   return r.BindExportImageToMemory(
@@ -6087,7 +6087,7 @@ raylib.LoadFontFromImage = LoadFontFromImage
  * Load font from memory buffer, fileType refers to extension: i.e. '.ttf'
  *
  * @param {string} fileType
- * @param {Buffer} fileData
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} fileData
  * @param {number} dataSize
  * @param {number} fontSize
  * @param {number} codepoints
@@ -6133,7 +6133,7 @@ raylib.IsFontValid = IsFontValid
 /**
  * Load font data for further use
  *
- * @param {Buffer} fileData
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} fileData
  * @param {number} dataSize
  * @param {number} fontSize
  * @param {number} codepoints
@@ -8853,7 +8853,7 @@ raylib.LoadWave = LoadWave
  * Load wave from memory buffer, fileType refers to extension: i.e. '.wav'
  *
  * @param {string} fileType
- * @param {Buffer} fileData
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} fileData
  * @param {number} dataSize
  *
  * @return {Wave} The resulting Wave.
@@ -9300,7 +9300,7 @@ raylib.LoadMusicStream = LoadMusicStream
  * Load music stream from data
  *
  * @param {string} fileType
- * @param {Buffer} data
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} data
  * @param {number} dataSize
  *
  * @return {Music} The resulting Music.
@@ -14872,7 +14872,7 @@ raylib.rlReadTexturePixels = rlReadTexturePixels
  * @param {number} width
  * @param {number} height
  *
- * @return {Buffer} The resulting unsigned char *.
+ * @return {Buffer|ArrayBuffer|ArrayBufferView} The resulting unsigned char *.
  */
 function rlReadScreenPixels(width, height) {
   return r.BindrlReadScreenPixels(

--- a/src/generated/node-raylib.cc
+++ b/src/generated/node-raylib.cc
@@ -70,6 +70,22 @@ inline double doubleFromValue(const Napi::CallbackInfo& info, int index) {
   return info[index].As<Napi::Number>().DoubleValue();
 }
 uintptr_t pointerFromValue(const Napi::CallbackInfo& info, int index) {
+  if (info[index].IsBuffer()) {
+    return (uintptr_t) info[index].As<Napi::Buffer<char>>().Data();
+  }
+  if (info[index].IsTypedArray()) {
+    Napi::TypedArray typedArray = info[index].As<Napi::TypedArray>();
+    Napi::ArrayBuffer buffer = typedArray.ArrayBuffer();
+    return (uintptr_t) ((unsigned char*)buffer.Data() + typedArray.ByteOffset());
+  }
+  if (info[index].IsArrayBuffer()) {
+    return (uintptr_t) info[index].As<Napi::ArrayBuffer>().Data();
+  }
+  if (info[index].IsDataView()) {
+    Napi::DataView dataView = info[index].As<Napi::DataView>();
+    Napi::ArrayBuffer buffer = dataView.ArrayBuffer();
+    return (uintptr_t) ((unsigned char*)buffer.Data() + dataView.ByteOffset());
+  }
   return (uintptr_t) info[index].As<Napi::Number>().Int64Value();
 }
 inline unsigned char unsignedcharFromValue(const Napi::CallbackInfo& info, int index) {

--- a/src/generated/node-raylib.d.ts
+++ b/src/generated/node-raylib.d.ts
@@ -203,7 +203,7 @@ declare module "raylib" {
     /** Vertex tangents (XYZW - 4 components per vertex) (shader-location = 4). (float *) */
     tangents: number
     /** Vertex colors (RGBA - 4 components per vertex) (shader-location = 3). (unsigned char *) */
-    colors: Buffer
+    colors: Buffer|ArrayBuffer|ArrayBufferView
     /** Vertex indices (in case vertex data comes indexed). (unsigned short *) */
     indices: number
     /** Animated vertex positions (after bones transformations). (float *) */
@@ -211,7 +211,7 @@ declare module "raylib" {
     /** Animated normals (after bones transformations). (float *) */
     animNormals: number
     /** Vertex bone ids, max 255 bone ids, up to 4 bones influence by vertex (skinning) (shader-location = 6). (unsigned char *) */
-    boneIds: Buffer
+    boneIds: Buffer|ArrayBuffer|ArrayBufferView
     /** Vertex bone weight, up to 4 bones influence by vertex (skinning) (shader-location = 7). (float *) */
     boneWeights: number
     /** Bones animated transformation matrices. (Matrix *) */
@@ -810,16 +810,16 @@ declare module "raylib" {
   export function MemFree(ptr: number): void
   
   /** Load file data as byte array (read) */
-  export function LoadFileData(fileName: string, dataSize: number): Buffer
+  export function LoadFileData(fileName: string, dataSize: number): Buffer|ArrayBuffer|ArrayBufferView
   
   /** Unload file data allocated by LoadFileData() */
-  export function UnloadFileData(data: Buffer): void
+  export function UnloadFileData(data: Buffer|ArrayBuffer|ArrayBufferView): void
   
   /** Save data to file from byte array (write), returns true on success */
   export function SaveFileData(fileName: string, data: number, dataSize: number): boolean
   
   /** Export data to code (.h), returns true on success */
-  export function ExportDataAsCode(data: Buffer, dataSize: number, fileName: string): boolean
+  export function ExportDataAsCode(data: Buffer|ArrayBuffer|ArrayBufferView, dataSize: number, fileName: string): boolean
   
   /** Load text data from file (read), returns a '\0' terminated string */
   export function LoadFileText(fileName: string): string
@@ -897,25 +897,25 @@ declare module "raylib" {
   export function GetFileModTime(fileName: string): number
   
   /** Compress data (DEFLATE algorithm), memory must be MemFree() */
-  export function CompressData(data: Buffer, dataSize: number, compDataSize: number): Buffer
+  export function CompressData(data: Buffer|ArrayBuffer|ArrayBufferView, dataSize: number, compDataSize: number): Buffer|ArrayBuffer|ArrayBufferView
   
   /** Decompress data (DEFLATE algorithm), memory must be MemFree() */
-  export function DecompressData(compData: Buffer, compDataSize: number, dataSize: number): Buffer
+  export function DecompressData(compData: Buffer|ArrayBuffer|ArrayBufferView, compDataSize: number, dataSize: number): Buffer|ArrayBuffer|ArrayBufferView
   
   /** Encode data to Base64 string, memory must be MemFree() */
-  export function EncodeDataBase64(data: Buffer, dataSize: number, outputSize: number): string
+  export function EncodeDataBase64(data: Buffer|ArrayBuffer|ArrayBufferView, dataSize: number, outputSize: number): string
   
   /** Decode Base64 string data, memory must be MemFree() */
-  export function DecodeDataBase64(data: Buffer, outputSize: number): Buffer
+  export function DecodeDataBase64(data: Buffer|ArrayBuffer|ArrayBufferView, outputSize: number): Buffer|ArrayBuffer|ArrayBufferView
   
   /** Compute CRC32 hash code */
-  export function ComputeCRC32(data: Buffer, dataSize: number): number
+  export function ComputeCRC32(data: Buffer|ArrayBuffer|ArrayBufferView, dataSize: number): number
   
   /** Compute MD5 hash code, returns static int[4] (16 bytes) */
-  export function ComputeMD5(data: Buffer, dataSize: number): number
+  export function ComputeMD5(data: Buffer|ArrayBuffer|ArrayBufferView, dataSize: number): number
   
   /** Compute SHA1 hash code, returns static int[5] (20 bytes) */
-  export function ComputeSHA1(data: Buffer, dataSize: number): number
+  export function ComputeSHA1(data: Buffer|ArrayBuffer|ArrayBufferView, dataSize: number): number
   
   /** Load automation events list from file, NULL for empty list, capacity = MAX_AUTOMATION_EVENTS */
   export function LoadAutomationEventList(fileName: string): AutomationEventList
@@ -1290,10 +1290,10 @@ declare module "raylib" {
   export function LoadImageAnim(fileName: string, frames: number): Image
   
   /** Load image sequence from memory buffer */
-  export function LoadImageAnimFromMemory(fileType: string, fileData: Buffer, dataSize: number, frames: number): Image
+  export function LoadImageAnimFromMemory(fileType: string, fileData: Buffer|ArrayBuffer|ArrayBufferView, dataSize: number, frames: number): Image
   
   /** Load image from memory buffer, fileType refers to extension: i.e. '.png' */
-  export function LoadImageFromMemory(fileType: string, fileData: Buffer, dataSize: number): Image
+  export function LoadImageFromMemory(fileType: string, fileData: Buffer|ArrayBuffer|ArrayBufferView, dataSize: number): Image
   
   /** Load image from GPU texture data */
   export function LoadImageFromTexture(texture: Texture): Image
@@ -1311,7 +1311,7 @@ declare module "raylib" {
   export function ExportImage(image: Image, fileName: string): boolean
   
   /** Export image to memory buffer */
-  export function ExportImageToMemory(image: Image, fileType: string, fileSize: number): Buffer
+  export function ExportImageToMemory(image: Image, fileType: string, fileSize: number): Buffer|ArrayBuffer|ArrayBufferView
   
   /** Export image as code file defining an array of bytes, returns true on success */
   export function ExportImageAsCode(image: Image, fileName: string): boolean
@@ -1638,13 +1638,13 @@ declare module "raylib" {
   export function LoadFontFromImage(image: Image, key: Color, firstChar: number): Font
   
   /** Load font from memory buffer, fileType refers to extension: i.e. '.ttf' */
-  export function LoadFontFromMemory(fileType: string, fileData: Buffer, dataSize: number, fontSize: number, codepoints: number, codepointCount: number): Font
+  export function LoadFontFromMemory(fileType: string, fileData: Buffer|ArrayBuffer|ArrayBufferView, dataSize: number, fontSize: number, codepoints: number, codepointCount: number): Font
   
   /** Check if a font is valid (font data loaded, WARNING: GPU texture not checked) */
   export function IsFontValid(font: Font): boolean
   
   /** Load font data for further use */
-  export function LoadFontData(fileData: Buffer, dataSize: number, fontSize: number, codepoints: number, codepointCount: number, type: number): number
+  export function LoadFontData(fileData: Buffer|ArrayBuffer|ArrayBufferView, dataSize: number, fontSize: number, codepoints: number, codepointCount: number, type: number): number
   
   /** Generate image font atlas using chars info */
   export function GenImageFontAtlas(glyphs: number, glyphRecs: number, glyphCount: number, fontSize: number, padding: number, packMethod: number): Image
@@ -1980,7 +1980,7 @@ declare module "raylib" {
   export function LoadWave(fileName: string): Wave
   
   /** Load wave from memory buffer, fileType refers to extension: i.e. '.wav' */
-  export function LoadWaveFromMemory(fileType: string, fileData: Buffer, dataSize: number): Wave
+  export function LoadWaveFromMemory(fileType: string, fileData: Buffer|ArrayBuffer|ArrayBufferView, dataSize: number): Wave
   
   /** Checks if wave data is valid (data loaded and parameters) */
   export function IsWaveValid(wave: Wave): boolean
@@ -2058,7 +2058,7 @@ declare module "raylib" {
   export function LoadMusicStream(fileName: string): Music
   
   /** Load music stream from data */
-  export function LoadMusicStreamFromMemory(fileType: string, data: Buffer, dataSize: number): Music
+  export function LoadMusicStreamFromMemory(fileType: string, data: Buffer|ArrayBuffer|ArrayBufferView, dataSize: number): Music
   
   /** Checks if a music stream is valid (context and buffers initialized) */
   export function IsMusicValid(music: Music): boolean
@@ -3174,7 +3174,7 @@ declare module "raylib" {
   export function rlReadTexturePixels(id: number, width: number, height: number, format: number): number
   
   /** Read screen pixel data (color buffer) */
-  export function rlReadScreenPixels(width: number, height: number): Buffer
+  export function rlReadScreenPixels(width: number, height: number): Buffer|ArrayBuffer|ArrayBufferView
   
   /** Load an empty framebuffer */
   export function rlLoadFramebuffer(): number

--- a/src/generated/node-raylib.js
+++ b/src/generated/node-raylib.js
@@ -1490,7 +1490,7 @@ raylib.MemFree = MemFree
  * @param {string} fileName
  * @param {number} dataSize
  *
- * @return {Buffer} The resulting unsigned char *.
+ * @return {Buffer|ArrayBuffer|ArrayBufferView} The resulting unsigned char *.
  */
 function LoadFileData(fileName, dataSize) {
   return r.BindLoadFileData(
@@ -1503,7 +1503,7 @@ raylib.LoadFileData = LoadFileData
 /**
  * Unload file data allocated by LoadFileData()
  *
- * @param {Buffer} data
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} data
  *
  * @return {undefined}
  */
@@ -1535,7 +1535,7 @@ raylib.SaveFileData = SaveFileData
 /**
  * Export data to code (.h), returns true on success
  *
- * @param {Buffer} data
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} data
  * @param {number} dataSize
  * @param {string} fileName
  *
@@ -1899,11 +1899,11 @@ raylib.GetFileModTime = GetFileModTime
 /**
  * Compress data (DEFLATE algorithm), memory must be MemFree()
  *
- * @param {Buffer} data
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} data
  * @param {number} dataSize
  * @param {number} compDataSize
  *
- * @return {Buffer} The resulting unsigned char *.
+ * @return {Buffer|ArrayBuffer|ArrayBufferView} The resulting unsigned char *.
  */
 function CompressData(data, dataSize, compDataSize) {
   return r.BindCompressData(
@@ -1917,11 +1917,11 @@ raylib.CompressData = CompressData
 /**
  * Decompress data (DEFLATE algorithm), memory must be MemFree()
  *
- * @param {Buffer} compData
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} compData
  * @param {number} compDataSize
  * @param {number} dataSize
  *
- * @return {Buffer} The resulting unsigned char *.
+ * @return {Buffer|ArrayBuffer|ArrayBufferView} The resulting unsigned char *.
  */
 function DecompressData(compData, compDataSize, dataSize) {
   return r.BindDecompressData(
@@ -1935,7 +1935,7 @@ raylib.DecompressData = DecompressData
 /**
  * Encode data to Base64 string, memory must be MemFree()
  *
- * @param {Buffer} data
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} data
  * @param {number} dataSize
  * @param {number} outputSize
  *
@@ -1953,10 +1953,10 @@ raylib.EncodeDataBase64 = EncodeDataBase64
 /**
  * Decode Base64 string data, memory must be MemFree()
  *
- * @param {Buffer} data
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} data
  * @param {number} outputSize
  *
- * @return {Buffer} The resulting unsigned char *.
+ * @return {Buffer|ArrayBuffer|ArrayBufferView} The resulting unsigned char *.
  */
 function DecodeDataBase64(data, outputSize) {
   return r.BindDecodeDataBase64(
@@ -1969,7 +1969,7 @@ raylib.DecodeDataBase64 = DecodeDataBase64
 /**
  * Compute CRC32 hash code
  *
- * @param {Buffer} data
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} data
  * @param {number} dataSize
  *
  * @return {number} The resulting unsigned int.
@@ -1985,7 +1985,7 @@ raylib.ComputeCRC32 = ComputeCRC32
 /**
  * Compute MD5 hash code, returns static int[4] (16 bytes)
  *
- * @param {Buffer} data
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} data
  * @param {number} dataSize
  *
  * @return {number} The resulting unsigned int *.
@@ -2001,7 +2001,7 @@ raylib.ComputeMD5 = ComputeMD5
 /**
  * Compute SHA1 hash code, returns static int[5] (20 bytes)
  *
- * @param {Buffer} data
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} data
  * @param {number} dataSize
  *
  * @return {number} The resulting unsigned int *.
@@ -4393,7 +4393,7 @@ raylib.LoadImageAnim = LoadImageAnim
  * Load image sequence from memory buffer
  *
  * @param {string} fileType
- * @param {Buffer} fileData
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} fileData
  * @param {number} dataSize
  * @param {number} frames
  *
@@ -4413,7 +4413,7 @@ raylib.LoadImageAnimFromMemory = LoadImageAnimFromMemory
  * Load image from memory buffer, fileType refers to extension: i.e. '.png'
  *
  * @param {string} fileType
- * @param {Buffer} fileData
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} fileData
  * @param {number} dataSize
  *
  * @return {Image} The resulting Image.
@@ -4518,7 +4518,7 @@ raylib.ExportImage = ExportImage
  * @param {string} fileType
  * @param {number} fileSize
  *
- * @return {Buffer} The resulting unsigned char *.
+ * @return {Buffer|ArrayBuffer|ArrayBufferView} The resulting unsigned char *.
  */
 function ExportImageToMemory(image, fileType, fileSize) {
   return r.BindExportImageToMemory(
@@ -6087,7 +6087,7 @@ raylib.LoadFontFromImage = LoadFontFromImage
  * Load font from memory buffer, fileType refers to extension: i.e. '.ttf'
  *
  * @param {string} fileType
- * @param {Buffer} fileData
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} fileData
  * @param {number} dataSize
  * @param {number} fontSize
  * @param {number} codepoints
@@ -6133,7 +6133,7 @@ raylib.IsFontValid = IsFontValid
 /**
  * Load font data for further use
  *
- * @param {Buffer} fileData
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} fileData
  * @param {number} dataSize
  * @param {number} fontSize
  * @param {number} codepoints
@@ -8853,7 +8853,7 @@ raylib.LoadWave = LoadWave
  * Load wave from memory buffer, fileType refers to extension: i.e. '.wav'
  *
  * @param {string} fileType
- * @param {Buffer} fileData
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} fileData
  * @param {number} dataSize
  *
  * @return {Wave} The resulting Wave.
@@ -9300,7 +9300,7 @@ raylib.LoadMusicStream = LoadMusicStream
  * Load music stream from data
  *
  * @param {string} fileType
- * @param {Buffer} data
+ * @param {Buffer|ArrayBuffer|ArrayBufferView} data
  * @param {number} dataSize
  *
  * @return {Music} The resulting Music.
@@ -14872,7 +14872,7 @@ raylib.rlReadTexturePixels = rlReadTexturePixels
  * @param {number} width
  * @param {number} height
  *
- * @return {Buffer} The resulting unsigned char *.
+ * @return {Buffer|ArrayBuffer|ArrayBufferView} The resulting unsigned char *.
  */
 function rlReadScreenPixels(width, height) {
   return r.BindrlReadScreenPixels(

--- a/tools/generate_templates/ArgumentTypeConversion.js
+++ b/tools/generate_templates/ArgumentTypeConversion.js
@@ -1,7 +1,6 @@
 function ArgumentTypeConversion (arg) {
   if (arg === 'const unsigned char *') { return 'Buffer|ArrayBuffer|ArrayBufferView' }
   if (arg === 'unsigned char *') { return 'Buffer|ArrayBuffer|ArrayBufferView' }
-  if (arg === 'void *' || arg === 'const void *') { return 'Buffer|ArrayBuffer|ArrayBufferView' }
 
   if (arg === 'char') { return 'string' }
   if (arg === 'char *') { return 'string' }

--- a/tools/generate_templates/ArgumentTypeConversion.js
+++ b/tools/generate_templates/ArgumentTypeConversion.js
@@ -1,6 +1,7 @@
 function ArgumentTypeConversion (arg) {
-  if (arg === 'const unsigned char *') { return 'Buffer' }
-  if (arg === 'unsigned char *') { return 'Buffer' }
+  if (arg === 'const unsigned char *') { return 'Buffer|ArrayBuffer|ArrayBufferView' }
+  if (arg === 'unsigned char *') { return 'Buffer|ArrayBuffer|ArrayBufferView' }
+  if (arg === 'void *' || arg === 'const void *') { return 'Buffer|ArrayBuffer|ArrayBufferView' }
 
   if (arg === 'char') { return 'string' }
   if (arg === 'char *') { return 'string' }

--- a/tools/generate_templates/node-raylib-bindings.js
+++ b/tools/generate_templates/node-raylib-bindings.js
@@ -266,6 +266,22 @@ inline double doubleFromValue(const Napi::CallbackInfo& info, int index) {
   return info[index].As<Napi::Number>().DoubleValue();
 }
 uintptr_t pointerFromValue(const Napi::CallbackInfo& info, int index) {
+  if (info[index].IsBuffer()) {
+    return (uintptr_t) info[index].As<Napi::Buffer<char>>().Data();
+  }
+  if (info[index].IsTypedArray()) {
+    Napi::TypedArray typedArray = info[index].As<Napi::TypedArray>();
+    Napi::ArrayBuffer buffer = typedArray.ArrayBuffer();
+    return (uintptr_t) ((unsigned char*)buffer.Data() + typedArray.ByteOffset());
+  }
+  if (info[index].IsArrayBuffer()) {
+    return (uintptr_t) info[index].As<Napi::ArrayBuffer>().Data();
+  }
+  if (info[index].IsDataView()) {
+    Napi::DataView dataView = info[index].As<Napi::DataView>();
+    Napi::ArrayBuffer buffer = dataView.ArrayBuffer();
+    return (uintptr_t) ((unsigned char*)buffer.Data() + dataView.ByteOffset());
+  }
   return (uintptr_t) info[index].As<Napi::Number>().Int64Value();
 }
 inline unsigned char unsignedcharFromValue(const Napi::CallbackInfo& info, int index) {


### PR DESCRIPTION
This PR adds support for more Buffer types. This should cover most buffers from Node and Bun but also DataView allows all kinds of different usecases. 

Huge caveat here though, I am NOT very familiar with Napi. I'm just greping around hacking my way through this and following some other existing code patterns and going off what my LSP is showing me inside of Napi.

I have obviously tested this myself as I now consume my fork for my game where I load images from memory ([briefly mentioned in an issue here](https://github.com/RobLoach/node-raylib/issues/189#issuecomment-3808765933)), and I use bun to compile a binary with the files embedded and its all working correctly now. But this obviously does NOT properly test all the various functions and interfaces that change with the generated bindings. 

Here is an example of the code I'm using to test these changes: 
<img width="943" height="278" alt="image" src="https://github.com/user-attachments/assets/c8be01bf-8242-4b62-bab7-c231125fca8f" />

And here is a small snippet of a diff of the new bindings (which im assuming we are not suppose to commit as part of PR's?)
<img width="1572" height="587" alt="image" src="https://github.com/user-attachments/assets/48427b26-40ee-41ce-9cdd-9b14fb812127" />


I am absolutely open to fixing any issues that I don't know about or extending this further with some guidance. I'm also totally ok to be told this isnt what is wanted and this PR closed. This fixes the problems I personally had with my own game and I figured I'll just shove it up here as an MR with low/no expectations of what happens with the MR itself. 